### PR TITLE
Fixed critical French translation errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,18 +79,18 @@
       <br><br>
       <center>-- WHAT TO BRING --</center>
       <br>
-      We highly recommend bringing a laptop with Kali Linux in a VM. Some other tools/languages you may need include: Wireshark, binary ninja/IDA, bin walk, photo manipulation tools, Java, Python. 
+      We highly recommend bringing a laptop with Kali Linux in a VM. Some other tools/languages you may need include: Wireshark, Binary Ninja/IDA, binwalk, photo manipulation tools, Java, Python. 
       <br><br>
       Good luck and see you there!
       <br><br>
       ---------------------------------------------------------------
       <br><br>
-      Venez nous rejoindre le samdi 16 juin de 12h à 20h pour une journée de hacking au Herzberg 4155!
-      Cette capture de drapeau de niveau débutant est une excellente façon de tester vos connaissances en cybersécurité. Avec tous les défis qui seront présentés, vous serez certains d'en apdivndre beaucoup! Tous les défis deviendront source-ouverte à la fin de l'évènement, alors si vous vous en accrochez sur un défi, vous pourriez voir les solutionnaires.
+      Venez nous rejoindre le samedi 18 août de 12h à 20h pour une journée de hacking au Herzberg 4155!
+      Cette capture de drapeau de niveau débutant est une excellente façon de tester vos connaissances en cybersécurité. Avec tous les défis qui seront présentés, vous serez certains d'en apprendre beaucoup! Tous les défis deviendront source ouverte à la fin de l'évènement, alors si vous vous se retrouvez coincé sur un défi, vous pourriez voir les solutionnaires.
       <br><br>
-      <center>--CE QU'IL FAUT APPORTER--</center>
+      <center>-- CE QU'IL FAUT APPORTER --</center>
       <br>
-      Il est fortement recommandé d'apporter un portable avec Kali Linux installé dans une machine virtuelle. De plus, vous aurez peut-être besoin des outils et langages suivants: Wireshark, Binary Ninja/IDA, bin walk, outils de manipulation d'images, Java, Python.
+      Il est fortement recommandé d'apporter un portable avec Kali Linux installé dans une machine virtuelle. De plus, vous aurez peut-être besoin des outils et langages suivants: Wireshark, Binary Ninja/IDA, binwalk, logiciels de retouche d'images, Java, Python.
       <br><br>
       Bonne chance!
     </div>


### PR DESCRIPTION
One isn't a perfect solution, but it should make a lot more sense to French speakers now.
It's more common to just say "open source" in French rather than "source ouverte", but I left it as-is as it's a beginner event, and corrected the grammatical gender.